### PR TITLE
Fixes for Warp 3.3

### DIFF
--- a/warp-grpc/package.yaml
+++ b/warp-grpc/package.yaml
@@ -1,5 +1,5 @@
 name:                warp-grpc
-version:             0.2.0.0
+version:             0.3.0.0
 github:              "haskell-grpc-native/http2-grpc-haskell"
 license:             BSD3
 author:              "Lucas DiCioccio, Alejandro Serrano"

--- a/warp-grpc/src/Network/GRPC/Server/Handlers.hs
+++ b/warp-grpc/src/Network/GRPC/Server/Handlers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE LambdaCase #-}
@@ -295,4 +296,4 @@ handleRequestChunksLoop decoder handleMsg handleEof nextChunk =
 errorOnLeftOver :: (a -> IO b) -> ByteString -> a -> IO b
 errorOnLeftOver f rest
   | ByteString.null rest = f
-  | otherwise            = const $ closeEarly $ GRPCStatus INVALID_ARGUMENT ("left-overs: " <> rest)
+  | otherwise            = const $ putStrLn "left-over" >> closeEarly (GRPCStatus INVALID_ARGUMENT ("left-overs: " <> rest))

--- a/warp-grpc/src/Network/GRPC/Server/Helpers.hs
+++ b/warp-grpc/src/Network/GRPC/Server/Helpers.hs
@@ -1,14 +1,18 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 module Network.GRPC.Server.Helpers where
 
 import qualified Data.ByteString.Char8 as ByteString
-import           Data.Maybe (fromMaybe)
-import           Network.GRPC.HTTP2.Types (GRPCStatus(..), trailerForStatusCode, grpcStatusH, grpcMessageH)
-#if MIN_VERSION_warp(3,3,0)
-import           Network.HTTP2.Server (NextTrailersMaker(..))
-#endif
+import           Data.IORef
+import           Network.GRPC.HTTP2.Types (HeaderValue, HeaderKey, GRPCStatus(..), trailerForStatusCode, grpcStatusH, grpcMessageH)
 import           Network.Wai (Request)
-import           Network.Wai.Handler.Warp (http2dataTrailers, defaultHTTP2Data, modifyHTTP2Data, HTTP2Data)
+
+#if MIN_VERSION_warp(3,3,0)
+
+#else
+import           Data.Maybe (fromMaybe)
+import           Network.Wai.Handler.Warp (http2dataTrailers, defaultHTTP2Data, modifyHTTP2Data)
+#endif
 
 #if MIN_VERSION_base(4,11,0)
 #else
@@ -16,21 +20,16 @@ import Data.Monoid ((<>))
 #endif
 
 -- | Helper to set the GRPCStatus on the trailers reply.
-modifyGRPCStatus :: Request -> GRPCStatus -> IO ()
-modifyGRPCStatus req = modifyHTTP2Data req . makeGRPCTrailers
-
-makeGRPCTrailers :: GRPCStatus -> (Maybe HTTP2Data -> Maybe HTTP2Data)
-makeGRPCTrailers (GRPCStatus s msg) h2data =
+modifyGRPCStatus :: IORef [(HeaderKey, HeaderValue)] -> Request -> GRPCStatus -> IO ()
 #if MIN_VERSION_warp(3,3,0)
-    Just $! (fromMaybe defaultHTTP2Data h2data) { http2dataTrailers = trailersMaker }
+modifyGRPCStatus ref _ (GRPCStatus s msg) =
+  writeIORef ref trailers
 #else
-    Just $! (fromMaybe defaultHTTP2Data h2data) { http2dataTrailers = trailers }
+modifyGRPCStatus _ req (GRPCStatus s msg) = modifyHTTP2Data req $ \h2data ->
+  Just $! (fromMaybe defaultHTTP2Data h2data) { http2dataTrailers = trailers }
 #endif
   where
-#if MIN_VERSION_warp(3,3,0)
-    trailersMaker (Just _) = return $ NextTrailersMaker trailersMaker
-    trailersMaker Nothing  = return $ Trailers trailers
-#endif
-    trailers = if ByteString.null msg then [status] else [status, message]
+    !trailers = if ByteString.null msg then [status] else [status, message]
     status = (grpcStatusH, trailerForStatusCode s)
     message = (grpcMessageH, msg)
+    

--- a/warp-grpc/src/Network/GRPC/Server/Wai.hs
+++ b/warp-grpc/src/Network/GRPC/Server/Wai.hs
@@ -9,6 +9,7 @@ import           Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as ByteString
 import           Data.ByteString.Lazy (fromStrict)
 import           Data.Binary.Builder (Builder)
+import           Data.IORef
 import           Data.Maybe (fromMaybe)
 import qualified Data.CaseInsensitive as CI
 import qualified Data.List as List
@@ -16,6 +17,10 @@ import           Network.GRPC.HTTP2.Encoding (Compression, Encoding(..), Decodin
 import           Network.GRPC.HTTP2.Types (GRPCStatus(..), GRPCStatusCode(..), grpcStatusH, grpcMessageH, grpcContentTypeHV, grpcEncodingH, grpcAcceptEncodingH)
 import           Network.HTTP.Types (status200, status404)
 import           Network.Wai (Application, Request(..), rawPathInfo, responseLBS, responseStream, requestHeaders)
+import           Network.Wai.Handler.Warp (http2dataTrailers, defaultHTTP2Data, modifyHTTP2Data)
+#if MIN_VERSION_warp(3,3,0)
+import           Network.HTTP2.Server (NextTrailersMaker(..))
+#endif
 
 #if MIN_VERSION_base(4,11,0)
 #else
@@ -68,6 +73,11 @@ closeEarly = throwIO
 -- This lookup may be inefficient for large amount of services.
 grpcService :: [Compression] -> [ServiceHandler] -> (Application -> Application)
 grpcService compressions services app = \req rep -> do
+    r <- newIORef []
+#if MIN_VERSION_warp(3,3,0)
+    modifyHTTP2Data req $ \h2data -> 
+      Just $! (fromMaybe defaultHTTP2Data h2data) { http2dataTrailers = trailersMaker r }
+#endif
     case lookupHandler (rawPathInfo req) services of
         Just handler ->
             -- Handler that catches early GRPC termination and other exceptions.
@@ -78,9 +88,11 @@ grpcService compressions services app = \req rep -> do
             -- These exceptions are swallowed from the WAI "onException"
             -- handler, so we'll need a better way to handle this case.
             let grpcHandler write flush =
-                    (doHandle handler req write flush)
-                    `catches` [ Handler $ \(e::GRPCStatus)    -> modifyGRPCStatus req e
-                              , Handler $ \(e::SomeException) -> modifyGRPCStatus req (GRPCStatus INTERNAL $ ByteString.pack $ show e )
+                    doHandle r handler req write flush
+                    `catches` [ Handler $ \(e::GRPCStatus)    ->
+                                 modifyGRPCStatus r req e
+                              , Handler $ \(e::SomeException) -> 
+                                 modifyGRPCStatus r req (GRPCStatus INTERNAL $ ByteString.pack $ show e)
                               ]
             in (rep $ responseStream status200 hdrs200 grpcHandler)
         Nothing ->
@@ -94,24 +106,31 @@ grpcService compressions services app = \req rep -> do
     lookupHandler :: ByteString -> [ServiceHandler] -> Maybe WaiHandler
     lookupHandler p plainHandlers = grpcWaiHandler <$>
         List.find (\(ServiceHandler rpcPath _) -> rpcPath == p) plainHandlers
-    doHandle handler req write flush = do
+    doHandle r handler req write flush = do
         let bestCompression = lookupEncoding req compressions
         let pickedCompression = fromMaybe (Encoding uncompressed) bestCompression
 
         let hopefulDecompression = lookupDecoding req compressions
         let pickedDecompression = fromMaybe (Decoding uncompressed) hopefulDecompression
 
+        putStrLn "running handler"
         _ <- handler pickedDecompression pickedCompression req write flush
-        modifyGRPCStatus req (GRPCStatus OK "WAI handler ended.")
+        putStrLn "setting GRPC status"
+        modifyGRPCStatus r req (GRPCStatus OK "WAI handler ended.")
+
+#if MIN_VERSION_warp(3,3,0)
+    trailersMaker r Nothing = Trailers <$> readIORef r
+    trailersMaker r _ = return $ NextTrailersMaker (trailersMaker r)
+#endif
 
 -- | Looks-up header for encoding outgoing messages.
 requestAcceptEncodingNames :: Request -> [ByteString]
-requestAcceptEncodingNames  req = fromMaybe [] $
-    ByteString.split ',' <$> lookup grpcAcceptEncodingH (requestHeaders req)
+requestAcceptEncodingNames  req = maybe [] (ByteString.split ',') $
+    lookup grpcAcceptEncodingH (requestHeaders req)
 
 -- | Looks-up the compression to use from a set of known algorithms.
 lookupEncoding :: Request -> [Compression] -> Maybe Encoding
-lookupEncoding req compressions = fmap Encoding $
+lookupEncoding req compressions = Encoding <$>
     safeHead [ c | c <- compressions
                  , n <- requestAcceptEncodingNames req
                  , n == grpcCompressionHV c


### PR DESCRIPTION
The current way of handling trailers does not work on Warp 3.3. This PR fixes this, although the mechanism ended up being a bit complicated:

* Now it's mandatory to set the `TrailersMaker` before the body,
* But exceptions and problems may arise in the body, because that's where we obtain the messages,
* The solution was to introduce an `IORef`, initially set at `OK`, but which is updated when one calls `modifyGRPCStatus`.

In order to support both Warp < 3.3 and Warp >= 3.3, I've left the code for the former.

Fixes #15 