### PR TITLE
Fix markdown

### DIFF
--- a/http2-client-grpc/Changelog.md
+++ b/http2-client-grpc/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-## 0.8.0.0
+## 0.8.0.0
 
 Fork `http2-client-grpc` to drop dependency on `proto-lens`.
 


### PR DESCRIPTION
Rendered version was off - probably some whitespace shenanigans.
I don't see a changelog for version 0.7.0.0 ?