### PR TITLE
Support unix and bare sockets

### DIFF
--- a/http2-client-grpc/Changelog.md
+++ b/http2-client-grpc/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+Support connecting to unix sockets and already connected sockets. [#44](https://github.com/haskell-grpc-native/http2-grpc-haskell/pull/44)
+
 ## 0.8.0.0
 
 Fork `http2-client-grpc` to drop dependency on `proto-lens`.

--- a/http2-client-grpc/http2-client-grpc.cabal
+++ b/http2-client-grpc/http2-client-grpc.cabal
@@ -26,10 +26,11 @@ library
                      , lifted-async >= 0.10 && < 0.11
                      , lifted-base >= 0.2 && < 0.3
                      , http2 >= 1.6 && < 2.1
-                     , http2-client >= 0.9 && < 0.10
+                     , http2-client >= 0.10 && < 0.11
                      , http2-grpc-types >= 0.5 && < 0.6
                      , text >= 1.2 && < 1.3
                      , tls >= 1.4 && < 1.6
+                     , network >= 2.6 && < 4
   default-language:    Haskell2010
 
 test-suite http2-client-grpc-test

--- a/http2-client-grpc/src/Network/GRPC/Client/Helpers.hs
+++ b/http2-client-grpc/src/Network/GRPC/Client/Helpers.hs
@@ -63,6 +63,8 @@ data BackgroundTasks = BackgroundTasks {
   -- ^ Periodically ping the server.
   }
 
+-- | A generalized address that supports new TCP connections, new UNIX socket
+-- connections or using already connected sockets
 data Address = AddressTCP HostName PortNumber
              | AddressUnix FilePath
              | AddressSocket Network.Socket Authority

--- a/stack-11.yaml
+++ b/stack-11.yaml
@@ -7,7 +7,7 @@ packages:
 - http2-client-grpc
 extra-deps:
 - proto3-wire-1.0.0
-- http2-client-0.9.0.0
+- http2-client-0.10.0.0
 - proto-lens-0.5.1.0
 - async-2.2.2
 - lifted-async-0.10.0.4

--- a/stack-12.yaml
+++ b/stack-12.yaml
@@ -7,5 +7,5 @@ packages:
 - http2-client-grpc
 extra-deps:
 - proto3-wire-1.0.0
-- http2-client-0.9.0.0
+- http2-client-0.10.0.0
 - proto-lens-0.5.1.0

--- a/stack-14.yaml
+++ b/stack-14.yaml
@@ -8,4 +8,4 @@ packages:
 - http2-client-grpc
 extra-deps:
 - proto3-wire-1.0.0
-- http2-client-0.9.0.0
+- http2-client-0.10.0.0

--- a/stack-15.yaml
+++ b/stack-15.yaml
@@ -8,4 +8,4 @@ packages:
 - http2-client-grpc
 extra-deps:
 - proto3-wire-1.0.0
-- http2-client-0.9.0.0
+- http2-client-0.10.0.0

--- a/stack-16.yaml
+++ b/stack-16.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.0
+resolver: lts-16.20
 allow-newer: true
 packages:
 - http2-grpc-types
@@ -9,4 +9,4 @@ packages:
 - bench-tool
 extra-deps:
 - proto3-wire-1.0.0
-- http2-client-0.9.0.0
+- http2-client-0.10.0.0

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -7,5 +7,5 @@ packages:
 - http2-client-grpc
 extra-deps:
 - proto3-wire-1.1.0
-- http2-client-0.9.0.0
+- http2-client-0.10.0.0
 allow-newer: true


### PR DESCRIPTION
Fixes #42 

I am not entirely certain about using `localhost` as the Authority. I added support for bare sockets because it seemed easy enough.