### PR TITLE
`waitReply` and `rawUnary` credit the connection

### DIFF
--- a/http2-client-grpc/http2-client-grpc.cabal
+++ b/http2-client-grpc/http2-client-grpc.cabal
@@ -26,7 +26,7 @@ library
                      , lifted-async >= 0.10 && < 0.11
                      , lifted-base >= 0.2 && < 0.3
                      , http2 >= 1.6 && < 2.1
-                     , http2-client >= 0.10 && < 0.11
+                     , http2-client >= 0.10.0.1 && < 0.12
                      , http2-grpc-types >= 0.5 && < 0.6
                      , text >= 1.2 && < 1.3
                      , tls >= 1.4 && < 1.6


### PR DESCRIPTION
This depends  on https://github.com/lucasdicioccio/http2-client/pull/75

The change in the functionality of `waitStream` means that `rawUnary`  queries do not rely on the background  thread sending WINDOW_UPDATE frames to progress.  This makes them perform with much lower latency  in some scenarious.