### PR TITLE
Client: Handle grpc-status

### DIFF
--- a/http2-client-grpc/http2-client-grpc.cabal
+++ b/http2-client-grpc/http2-client-grpc.cabal
@@ -23,6 +23,7 @@ library
                      , bytestring >= 0.10.8 && < 0.11
                      , case-insensitive >= 1.2.0 && < 1.3
                      , data-default-class >= 0.1 && <0.2
+                     , either >= 5 && < 6
                      , lifted-async >= 0.10 && < 0.11
                      , lifted-base >= 0.2 && < 0.3
                      , http2 >= 1.6 && < 2.1

--- a/http2-grpc-types/src/Network/GRPC/HTTP2/Types.hs
+++ b/http2-grpc-types/src/Network/GRPC/HTTP2/Types.hs
@@ -149,6 +149,7 @@ trailers (GRPCStatus s msg) =
     if ByteString.null msg then [status] else [status, message]
   where
     status = (grpcStatusH, trailerForStatusCode s)
+    -- TODO: This should be encoded to percent-encoding
     message = (grpcMessageH, msg)
 
 -- | In case a server replies with a gRPC status/message pair un-understood by this library.
@@ -163,6 +164,7 @@ readTrailers pairs = maybe (Left $ InvalidGRPCStatus pairs) Right $ do
     status <- statusCodeForTrailer =<< lookup grpcStatusH pairs
     return $ GRPCStatus status message
   where
+    -- TODO: This should be decoded from percent-encoding
     message = fromMaybe "" (lookup grpcMessageH pairs)
 
 -- | A class to represent RPC information.


### PR DESCRIPTION
Any non OK grpc status is stringified to not make a breaking API change. Ideally
this would not be the case as the status can be useful for the application.

This commit also reverts the assumption that presence of grpc-message implies an
error. This is not according to the specification and even the server in this
repository sometimes sets grpc-message on OK. This didn't cause any issues
because the grpc-message was being lookup in the HTTP headers, while according
to the spec it must always be set in the trailers.

Partially fixes #6