### PR TITLE
builds for stackage 17.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 install:
 # Build dependencies
 - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-nightly.yaml
+- stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-17.yaml
 - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-16.yaml
 - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-15.yaml
 - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-14.yaml
@@ -33,6 +34,7 @@ install:
 script:
 # Build the package, its tests, and its docs and run the tests
 - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-nightly.yaml
+- stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-17.yaml
 - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-16.yaml
 - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-15.yaml
 - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-14.yaml

--- a/stack-17.yaml
+++ b/stack-17.yaml
@@ -1,0 +1,12 @@
+resolver: lts-17.11
+allow-newer: true
+packages:
+- http2-grpc-types
+- http2-grpc-proto-lens
+- http2-grpc-proto3-wire
+- warp-grpc
+- http2-client-grpc
+- bench-tool
+extra-deps:
+- proto3-wire-1.0.0
+- http2-client-0.10.0.0

--- a/stack-17.yaml
+++ b/stack-17.yaml
@@ -1,12 +1,12 @@
-resolver: lts-17.11
+resolver: lts-17.2
 allow-newer: true
 packages:
-- http2-grpc-types
-- http2-grpc-proto-lens
-- http2-grpc-proto3-wire
-- warp-grpc
-- http2-client-grpc
-- bench-tool
+  - http2-grpc-types
+  - http2-grpc-proto-lens
+  - http2-grpc-proto3-wire
+  - warp-grpc
+  - http2-client-grpc
+  - bench-tool
 extra-deps:
-- proto3-wire-1.0.0
-- http2-client-0.10.0.0
+  - proto3-wire-1.0.0
+  - http2-client-0.10.0.0

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,11 +1,13 @@
-resolver: nightly-2020-06-12
+resolver: nightly-2021-05-10
 packages:
-- http2-grpc-types
-- http2-grpc-proto-lens
-- http2-grpc-proto3-wire
-- warp-grpc
-- http2-client-grpc
+  - http2-client-grpc
+  - http2-grpc-proto-lens
+  - http2-grpc-proto3-wire
+  - http2-grpc-types
+  - warp-grpc
 extra-deps:
-- proto3-wire-1.1.0
-- http2-client-0.10.0.0
+  - http2-2.0.6
+  - http2-client-0.10.0.0
+  - proto3-wire-1.1.0
+  - warp-3.3.14
 allow-newer: true


### PR DESCRIPTION
I am looking to try and revitalize this library as grpc for Haskell is in the critical path of what I am doing and will be for the foreseeable future. I would like to start by adding support for GHC-8.10.4 and stackage-17.11 found in this PR. The next step I would like to do is to get this package, and all of its dependencies set up for stackage 17 and consequently into stackage. I am unsure what needs to be done for this next step.

Thank you.