### PR TITLE
Environment tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,24 +21,27 @@ before_install:
   - export PATH=$HOME/.local/bin:$PATH
   - travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
-install:
-  # Build dependencies
-  # - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-nightly.yaml
-  - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-18.yaml
-  - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-17.yaml
-  - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-16.yaml
-  - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-15.yaml
-  - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-14.yaml
-# - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-12.yaml
-# - stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-11.yaml
-
-script:
-  # Build the package, its tests, and its docs and run the tests
-  # - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-nightly.yaml
-  - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-18.yaml
-  - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-17.yaml
-  - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-16.yaml
-  - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-15.yaml
-  - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-14.yaml
-# - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-12.yaml
-# - stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-11.yaml
+jobs:
+  fast_finish: true
+  include:
+    - name: "Stackage 18.x"
+      script: stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-18.yaml
+      install: stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-18.yaml
+    - name: "Stackage 17.x"
+      script: stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-17.yaml
+      install: stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-17.yaml
+    - name: "Stackage 16.x"
+      script: stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-16.yaml
+      install: stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-16.yaml
+    - name: "Stackage 15.x"
+      script: stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-15.yaml
+      install: stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-15.yaml
+    - name: "Stackage 14.x"
+      script: stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-14.yaml
+      install: stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-14.yaml
+    # - name: "Stackage 12.x"
+    #   script: stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-12.yaml
+    #   install: stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-12.yaml
+    # - name: "Stackage 11.x"
+    #   script: stack --no-terminal test --haddock --no-haddock-deps --stack-yaml stack-11.yaml
+    #   install: stack --no-terminal --install-ghc test --only-dependencies --stack-yaml stack-11.yaml

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,68 @@
+cradle:
+  multi:
+    - path: "bench-tool"
+      config:
+        cradle:
+          stack:
+    - path: "bench-tool/Setup.hs"
+      config:
+        cradle:
+          direct:
+            arguments:
+              - "-package Cabal"
+              - "-package base"
+    - path: "http2-client-grpc"
+      config:
+        cradle:
+          stack:
+    - path: "http2-client-grpc/Setup.hs"
+      config:
+        cradle:
+          direct:
+            arguments:
+              - "-package Cabal"
+              - "-package base"
+    - path: "http2-grpc-proto-lens"
+      config:
+        cradle:
+          stack:
+    - path: "http2-grpc-proto-lens/Setup.hs"
+      config:
+        cradle:
+          direct:
+            arguments:
+              - "-package Cabal"
+              - "-package base"
+    - path: "http2-grpc-proto3-wire"
+      config:
+        cradle:
+          stack:
+    - path: "http2-grpc-proto3-wire/Setup.hs"
+      config:
+        cradle:
+          direct:
+            arguments:
+              - "-package Cabal"
+              - "-package base"
+    - path: "http2-grpc-types"
+      config:
+        cradle:
+          stack:
+    - path: "http2-grpc-types/Setup.hs"
+      config:
+        cradle:
+          direct:
+            arguments:
+              - "-package Cabal"
+              - "-package base"
+    - path: "warp-grpc"
+      config:
+        cradle:
+          stack:
+    - path: "warp-grpc/Setup.hs"
+      config:
+        cradle:
+          direct:
+            arguments:
+              - "-package Cabal"
+              - "-package base"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+stack-18.yaml

--- a/test-builds.sh
+++ b/test-builds.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+stack build --stack-yaml=stack-11.yaml
+stack build --stack-yaml=stack-12.yaml
+stack build --stack-yaml=stack-14.yaml
+stack build --stack-yaml=stack-15.yaml
+stack build --stack-yaml=stack-16.yaml
+stack build --stack-yaml=stack-17.yaml
+stack build --stack-yaml=stack-18.yaml


### PR DESCRIPTION
Symlinks stack.yaml to stack-18.yaml, since HLS requires a bare stack.yaml to run.
Adds hie.yaml so that this can be developed in HLS
Adds script to test all supported LTS versions

EDIT: this also will speed up travis builds significantly and reduce individual cache sizes