### PR TITLE
Explicit handling of input and output

### DIFF
--- a/bench-tool/src/BenchTool.hs
+++ b/bench-tool/src/BenchTool.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
 
 module BenchTool where
 
@@ -29,7 +30,7 @@ import qualified Network.GRPC.Client.Helpers as Client
 import Network.GRPC.HTTP2.Encoding as Encoding
 import qualified Network.GRPC.HTTP2.ProtoLens as ProtoLens
 import Network.GRPC.Server as Server
-import qualified Network.HTTP2.Client as Client
+import qualified "http2-client" Network.HTTP2.Client as Client
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Network.Wai.Handler.WarpTLS as WarpTLS
 import Options.Generic

--- a/http2-client-grpc/src/Network/GRPC/Client.hs
+++ b/http2-client-grpc/src/Network/GRPC/Client.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PackageImports      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 
@@ -96,7 +97,7 @@ import Network.GRPC.HTTP2.Types
 import Network.GRPC.HTTP2.Encoding
 import Network.HTTP2
 import Network.HPACK
-import Network.HTTP2.Client hiding (next)
+import "http2-client" Network.HTTP2.Client hiding (next)
 import Network.HTTP2.Client.Helpers
 
 type CIHeaderList = [(CI ByteString, ByteString)]

--- a/http2-client-grpc/src/Network/GRPC/Client/Helpers.hs
+++ b/http2-client-grpc/src/Network/GRPC/Client/Helpers.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE PackageImports    #-}
 {-# LANGUAGE CPP               #-}
 
 -- | Set of helpers helping with writing gRPC clients with not much exposure of
@@ -32,9 +33,9 @@ import Network.HPACK (HeaderList)
 import Data.Monoid ((<>))
 #endif
 
-import Network.HTTP2.Client (frameHttp2RawConnection, ClientIO, ClientError, newHttp2FrameConnection, newHttp2Client, Http2Client(..), IncomingFlowControl(..), GoAwayHandler, FallBackFrameHandler, ignoreFallbackHandler, HostName, PortNumber, TooMuchConcurrency)
-import Network.HTTP2.Client.Helpers (ping)
-import Network.HTTP2.Client.RawConnection (newRawHttp2ConnectionSocket, newRawHttp2ConnectionUnix)
+import "http2-client" Network.HTTP2.Client (frameHttp2RawConnection, ClientIO, ClientError, newHttp2FrameConnection, newHttp2Client, Http2Client(..), IncomingFlowControl(..), GoAwayHandler, FallBackFrameHandler, ignoreFallbackHandler, HostName, PortNumber, TooMuchConcurrency)
+import "http2-client" Network.HTTP2.Client.Helpers (ping)
+import "http2-client" Network.HTTP2.Client.RawConnection (newRawHttp2ConnectionSocket, newRawHttp2ConnectionUnix)
 import Network.GRPC.Client
 import Network.GRPC.HTTP2.Encoding
 import qualified Network.Socket as Network

--- a/http2-client-grpc/src/Network/GRPC/Client/Helpers.hs
+++ b/http2-client-grpc/src/Network/GRPC/Client/Helpers.hs
@@ -235,11 +235,11 @@ rawGeneralStream
   -- ^ An initialized client.
   -> a
   -- ^ An initial state for the incoming loop.
-  -> (a -> IncomingEvent o a -> ClientIO a)
+  -> (a -> IncomingEvent o -> ClientIO a)
   -- ^ A state-passing function for the incoming loop.
   -> b
   -- ^ An initial state for the outgoing loop.
-  -> (b -> ClientIO (b, OutgoingEvent i b))
+  -> (b -> ClientIO (b, OutgoingEvent i))
   -- ^ A state-passing function for the ougoing loop.
   -> ClientIO (Either TooMuchConcurrency (a,b))
 rawGeneralStream rpc (GrpcClient client authority headers timeout compression _) v0 handler w0 next =

--- a/stack-18.yaml
+++ b/stack-18.yaml
@@ -8,9 +8,7 @@ packages:
   - http2-client-grpc
   - bench-tool
 extra-deps:
-  - http2-2.0.6
   - http2-client-0.10.0.0
   - proto-lens-0.7.0.0
   - proto-lens-runtime-0.7.0.0
   - proto3-wire-1.0.0
-  - warp-3.3.14

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -6,8 +6,6 @@ packages:
   - http2-grpc-types
   - warp-grpc
 extra-deps:
-  - http2-2.0.6
   - http2-client-0.10.0.0
   - proto3-wire-1.1.0
-  - warp-3.3.14
 allow-newer: true

--- a/warp-grpc/.gitignore
+++ b/warp-grpc/.gitignore
@@ -1,5 +1,3 @@
 .stack-work/
-http2-server-grpc.cabal
-warp-grpc.cabal
 *~
 stack.yaml.lock

--- a/warp-grpc/src/Network/GRPC/Server/Handlers.hs
+++ b/warp-grpc/src/Network/GRPC/Server/Handlers.hs
@@ -9,6 +9,8 @@ module Network.GRPC.Server.Handlers (
 , bidiStream
 , H.GeneralStreamHandler, H.IncomingStream(..), H.OutgoingStream(..)
 , generalStream
+, H.ExplicitStreamHandler
+, explicitStream
 ) where
 
 import           Network.GRPC.HTTP2.Encoding
@@ -49,3 +51,10 @@ generalStream
   -> H.GeneralStreamHandler IO i o a b
   -> ServiceHandler
 generalStream = H.generalStream id
+
+explicitStream
+  :: (GRPCInput r i, GRPCOutput r o)
+  => r
+  -> H.ExplicitStreamHandler IO i o
+  -> ServiceHandler
+explicitStream = H.explicitStream id

--- a/warp-grpc/src/Network/GRPC/Server/Handlers/Unlift.hs
+++ b/warp-grpc/src/Network/GRPC/Server/Handlers/Unlift.hs
@@ -9,6 +9,8 @@ module Network.GRPC.Server.Handlers.Unlift (
 , bidiStream
 , H.GeneralStreamHandler, H.IncomingStream(..), H.OutgoingStream(..)
 , generalStream
+, H.ExplicitStreamHandler
+, explicitStream
 ) where
 
 import           Control.Monad.IO.Unlift
@@ -55,3 +57,11 @@ generalStream
   -> m ServiceHandler
 generalStream rpc handler
   = withRunInIO (\f -> return $ H.generalStream f rpc handler)
+
+explicitStream
+  :: (MonadUnliftIO m, GRPCInput r i, GRPCOutput r o)
+  => r
+  -> H.ExplicitStreamHandler m i o
+  -> m ServiceHandler
+explicitStream rpc handler
+  = withRunInIO (\f -> return $ H.explicitStream f rpc handler)

--- a/warp-grpc/warp-grpc.cabal
+++ b/warp-grpc/warp-grpc.cabal
@@ -1,0 +1,54 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.6.
+--
+-- see: https://github.com/sol/hpack
+
+name:           warp-grpc
+version:        0.4.0.1
+synopsis:       A minimal gRPC server on top of Warp.
+description:    Please see the README on Github at <https://github.com/haskell-grpc-native/http2-grpc-haskell/blob/master/warp-grpc/README.md>
+category:       Networking
+homepage:       https://github.com/haskell-grpc-native/http2-grpc-haskell#readme
+bug-reports:    https://github.com/haskell-grpc-native/http2-grpc-haskell/issues
+author:         Lucas DiCioccio, Alejandro Serrano
+maintainer:     lucas@dicioccio.fr
+copyright:      2017 - 2020 Lucas DiCioccio, Alejandro Serrano
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/haskell-grpc-native/http2-grpc-haskell
+
+library
+  exposed-modules:
+      Network.GRPC.Server
+      Network.GRPC.Server.Handlers
+      Network.GRPC.Server.Handlers.Trans
+      Network.GRPC.Server.Handlers.Unlift
+      Network.GRPC.Server.Helpers
+      Network.GRPC.Server.Wai
+  other-modules:
+      Paths_warp_grpc
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      async >=2.2.1 && <3
+    , base >=4.10 && <5
+    , binary >=0.8.5 && <0.9
+    , bytestring >=0.10.8 && <0.11
+    , case-insensitive >=1.2.0 && <1.3
+    , http-types ==0.12.*
+    , http2 >=1.6 && <3
+    , http2-grpc-types ==0.5.*
+    , unliftio-core >=0.1 && <0.3
+    , wai >=3.2 && <3.4
+    , warp >=3.2.23 && <3.4
+    , warp-tls >=3.2 && <3.4
+  default-language: Haskell2010


### PR DESCRIPTION
I wanted to use the library within an existing application that uses conduit as its main abstraction. None of the existing handlers made it possible to integrate that use-case.

I haven't tested the code yet. There should probably be a test-suite.