### PR TITLE
Use http2-client PackageImports

### DIFF
--- a/http2-client-grpc/src/Network/GRPC/Client.hs
+++ b/http2-client-grpc/src/Network/GRPC/Client.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PackageImports      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 
@@ -96,8 +97,8 @@ import Network.GRPC.HTTP2.Types
 import Network.GRPC.HTTP2.Encoding
 import Network.HTTP2
 import Network.HPACK
-import Network.HTTP2.Client hiding (next)
-import Network.HTTP2.Client.Helpers
+import "http2-client" Network.HTTP2.Client hiding (next)
+import "http2-client" Network.HTTP2.Client.Helpers
 
 type CIHeaderList = [(CI ByteString, ByteString)]
 

--- a/http2-client-grpc/src/Network/GRPC/Client/Helpers.hs
+++ b/http2-client-grpc/src/Network/GRPC/Client/Helpers.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE CPP               #-}
+{-# LANGUAGE PackageImports    #-}
 
 -- | Set of helpers helping with writing gRPC clients with not much exposure of
 -- the http2-client complexity.
@@ -32,7 +33,7 @@ import Network.HPACK (HeaderList)
 import Data.Monoid ((<>))
 #endif
 
-import Network.HTTP2.Client (frameHttp2RawConnection, ClientIO, ClientError, newHttp2FrameConnection, newHttp2Client, Http2Client(..), IncomingFlowControl(..), GoAwayHandler, FallBackFrameHandler, ignoreFallbackHandler, HostName, PortNumber, TooMuchConcurrency)
+import "http2-client" Network.HTTP2.Client (frameHttp2RawConnection, ClientIO, ClientError, newHttp2FrameConnection, newHttp2Client, Http2Client(..), IncomingFlowControl(..), GoAwayHandler, FallBackFrameHandler, ignoreFallbackHandler, HostName, PortNumber, TooMuchConcurrency)
 import Network.HTTP2.Client.Helpers (ping)
 import Network.HTTP2.Client.RawConnection (newRawHttp2ConnectionSocket, newRawHttp2ConnectionUnix)
 import Network.GRPC.Client


### PR DESCRIPTION
Newer versions of the `http2` package have their own `Network.HTTP2.Client` module, so we must use package-qualified imports.