### PR TITLE
Add support for GHC 9

### DIFF
--- a/bench-tool/bench-tool.cabal
+++ b/bench-tool/bench-tool.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e2c0b94f518b929cef4b5d01f972bc4e25cde9360b6bcc532730e62dea7187a5
+-- hash: 55d227f1000a57af28adf509eeccdb465720fbf0a9766ae0ae4f8a897276d7d1
 
 name:           bench-tool
 version:        0.4.0.1
@@ -44,7 +44,6 @@ library
     , case-insensitive >=1.2.0 && <1.3
     , containers
     , http-types ==0.12.*
-    , http2 >=1.6 && <3
     , http2-client
     , http2-client-grpc
     , http2-grpc-proto-lens
@@ -80,7 +79,6 @@ executable bench-tool-exe
     , case-insensitive >=1.2.0 && <1.3
     , containers
     , http-types ==0.12.*
-    , http2 >=1.6 && <3
     , http2-client
     , http2-client-grpc
     , http2-grpc-proto-lens

--- a/bench-tool/package.yaml
+++ b/bench-tool/package.yaml
@@ -21,7 +21,6 @@ dependencies:
 - binary >= 0.8.5 && < 0.9
 - bytestring >= 0.10.8 && < 0.11
 - case-insensitive >= 1.2.0 && < 1.3
-- http2 >= 1.6 && < 3
 - http2-grpc-types >= 0.5 && < 0.6
 - http-types >= 0.12 && < 0.13
 - unliftio-core >= 0.1 && < 0.3

--- a/http2-client-grpc/http2-client-grpc.cabal
+++ b/http2-client-grpc/http2-client-grpc.cabal
@@ -20,12 +20,12 @@ library
   build-depends:       base >= 4.10 && < 5
                      , async >= 2.2 && < 2.3
                      , binary >= 0.8 && < 0.9
-                     , bytestring >= 0.10.8 && < 0.11
+                     , bytestring >= 0.10.8 && < 0.12
                      , case-insensitive >= 1.2.0 && < 1.3
                      , data-default-class >= 0.1 && <0.2
                      , lifted-async >= 0.10 && < 0.11
                      , lifted-base >= 0.2 && < 0.3
-                     , http2 >= 1.6 && < 2.1
+                     , http2 >= 3.0 && < 3.1
                      , http2-client >= 0.10 && < 0.11
                      , http2-grpc-types >= 0.5 && < 0.6
                      , text >= 1.2 && < 1.3

--- a/http2-client-grpc/src/Network/GRPC/Client/Helpers.hs
+++ b/http2-client-grpc/src/Network/GRPC/Client/Helpers.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE CPP               #-}
+{-# LANGUAGE PackageImports    #-}
 
 -- | Set of helpers helping with writing gRPC clients with not much exposure of
 -- the http2-client complexity.
@@ -25,14 +26,13 @@ import Data.ByteString.Char8 (ByteString)
 import Data.Default.Class (def)
 import qualified Network.TLS as TLS
 import qualified Network.TLS.Extra.Cipher as TLS
-import Network.HPACK (HeaderList)
 
 #if MIN_VERSION_base(4,11,0)
 #else
 import Data.Monoid ((<>))
 #endif
 
-import Network.HTTP2.Client (frameHttp2RawConnection, ClientIO, ClientError, newHttp2FrameConnection, newHttp2Client, Http2Client(..), IncomingFlowControl(..), GoAwayHandler, FallBackFrameHandler, ignoreFallbackHandler, HostName, PortNumber, TooMuchConcurrency)
+import "http2-client" Network.HTTP2.Client (frameHttp2RawConnection, ClientIO, ClientError, newHttp2FrameConnection, newHttp2Client, Http2Client(..), IncomingFlowControl(..), GoAwayHandler, FallBackFrameHandler, ignoreFallbackHandler, HostName, PortNumber, TooMuchConcurrency)
 import Network.HTTP2.Client.Helpers (ping)
 import Network.HTTP2.Client.RawConnection (newRawHttp2ConnectionSocket, newRawHttp2ConnectionUnix)
 import Network.GRPC.Client

--- a/http2-grpc-proto-lens/http2-grpc-proto-lens.cabal
+++ b/http2-grpc-proto-lens/http2-grpc-proto-lens.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 57a4f4c88bc0fead3bcfeb0a5ceb013176d1102a131d797f0d2273d03db1c760
+-- hash: b8e5e20414580fa874a85f16cdafdd883f66c7e2f215e9e2ca25ae951b5470ab
 
 name:           http2-grpc-proto-lens
 version:        0.1.0.0
@@ -38,7 +38,7 @@ library
   build-depends:
       base >=4.10 && <5
     , binary >=0.8.5 && <0.11
-    , bytestring >=0.10.8 && <0.11
+    , bytestring >=0.10.8 && <0.12
     , case-insensitive >=1.2.0 && <1.3
     , http2-grpc-types
     , proto-lens >=0.5 && <0.8

--- a/http2-grpc-proto-lens/package.yaml
+++ b/http2-grpc-proto-lens/package.yaml
@@ -23,7 +23,7 @@ dependencies:
 - base >= 4.10 && < 5
 - http2-grpc-types
 - binary >= 0.8.5 && < 0.11
-- bytestring >= 0.10.8 && < 0.11
+- bytestring >= 0.10.8 && < 0.12
 - case-insensitive >= 1.2.0 && < 1.3
 - zlib >= 0.6.2 && < 0.7
 - proto-lens >= 0.5 && < 0.8

--- a/http2-grpc-proto3-wire/http2-grpc-proto3-wire.cabal
+++ b/http2-grpc-proto3-wire/http2-grpc-proto3-wire.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7dc4b2158bfca69e18262ad3e9432df60c5ae0d5be20324954b66b51420750a4
+-- hash: 304a39ccf01d8fa7f4be733a59b8257ddf85c6d3141be2869e5d4a4c16380b37
 
 name:           http2-grpc-proto3-wire
 version:        0.1.0.1
@@ -38,9 +38,9 @@ library
   build-depends:
       base >=4.10 && <5
     , binary >=0.8.5 && <0.11
-    , bytestring >=0.10.8 && <0.11
+    , bytestring >=0.10.8 && <0.12
     , case-insensitive >=1.2.0 && <1.3
     , http2-grpc-types
-    , proto3-wire >=1 && <=1.1
+    , proto3-wire >=1 && <1.4
     , zlib >=0.6.2 && <0.7
   default-language: Haskell2010

--- a/http2-grpc-proto3-wire/package.yaml
+++ b/http2-grpc-proto3-wire/package.yaml
@@ -23,10 +23,10 @@ dependencies:
 - base >= 4.10 && < 5
 - http2-grpc-types
 - binary >= 0.8.5 && < 0.11
-- bytestring >= 0.10.8 && < 0.11
+- bytestring >= 0.10.8 && < 0.12
 - case-insensitive >= 1.2.0 && < 1.3
 - zlib >= 0.6.2 && < 0.7
-- proto3-wire >= 1 && <= 1.1
+- proto3-wire >= 1 && < 1.4
 
 library:
   source-dirs: src

--- a/http2-grpc-types/http2-grpc-types.cabal
+++ b/http2-grpc-types/http2-grpc-types.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d6b648c1e4df6998a88b402927190c2ea0d5ee85a34c705a89096e0f1b6ab308
+-- hash: 4fc6ad32579862f06de9bd4b1fc6fe1aeafc3367821e6e5376db972fa0997274
 
 name:           http2-grpc-types
 version:        0.5.0.0
@@ -39,7 +39,7 @@ library
   build-depends:
       base >=4.10 && <5
     , binary >=0.8.5 && <0.11
-    , bytestring >=0.10.8 && <0.11
+    , bytestring >=0.10.8 && <0.12
     , case-insensitive >=1.2.0 && <1.3
     , zlib >=0.6.2 && <0.7
   default-language: Haskell2010

--- a/http2-grpc-types/package.yaml
+++ b/http2-grpc-types/package.yaml
@@ -22,7 +22,7 @@ description:         Please see the README on GitHub at <https://github.com/hask
 dependencies:
 - base >= 4.10 && < 5
 - binary >= 0.8.5 && < 0.11
-- bytestring >= 0.10.8 && < 0.11
+- bytestring >= 0.10.8 && < 0.12
 - case-insensitive >= 1.2.0 && < 1.3
 - zlib >= 0.6.2 && < 0.7
 

--- a/stack-11.yaml
+++ b/stack-11.yaml
@@ -6,8 +6,17 @@ packages:
 - warp-grpc
 - http2-client-grpc
 extra-deps:
+- http2-3.0.3@sha256:309c7198fbccf136e949a2b630d7fec2557478c4af4a2c8c5523b71ec00c88b9,15906
+- git: https://github.com/lucasdicioccio/http2-client
+  commit: 046b1f23ea547b75f1a3dc3d878603968bff4fb4
 - proto3-wire-1.0.0
-- http2-client-0.10.0.0
-- proto-lens-0.5.1.0
-- async-2.2.2
-- lifted-async-0.10.0.4
+- warp-3.3.15
+- warp-tls-3.2.12
+- tls-1.5.4
+- async-2.2.4@sha256:b83dec34a53520de84c6dd3dc7aae45d22409b46eb471c478b98108215a370f0,3095
+- lifted-async-0.10.2.2@sha256:7fa02000931faaee85723ada9bcb1c7773cfcea740113f62ea60c0bd84f9dfcf,2799
+- network-byte-order-0.1.6@sha256:23d8b609ac43a69d04d5e8f411e5f86a0266c0e8b33b65f8c92ebda64273fe3a,1313
+- proto-lens-0.7.1.1@sha256:8419e86fd7f521206a991c3ccb1777332a07a8250b380b06694f9f301b1ff38d,2972
+- time-manager-0.0.0@sha256:d258b1d08f9b926823f5380e9201303b0ebeefe4f9e0047c0cbd7b6728135ee1,657
+- x509-1.7.7@sha256:90eef2d745a654146fc1c325e035eaddac531e4d2145d4bc1dcf4b8fad439d34,2276
+- tls-session-manager-0.0.4@sha256:3b2e7e40b5be043b35a19fe1ed8b7e016a9c827f55777a9f9cb5e08860390d5d,1031

--- a/stack-12.yaml
+++ b/stack-12.yaml
@@ -6,6 +6,14 @@ packages:
 - warp-grpc
 - http2-client-grpc
 extra-deps:
+- http2-3.0.3@sha256:309c7198fbccf136e949a2b630d7fec2557478c4af4a2c8c5523b71ec00c88b9,15906
+- git: https://github.com/lucasdicioccio/http2-client
+  commit: 046b1f23ea547b75f1a3dc3d878603968bff4fb4
+- proto-lens-0.7.1.1@sha256:8419e86fd7f521206a991c3ccb1777332a07a8250b380b06694f9f301b1ff38d,2972
 - proto3-wire-1.0.0
-- http2-client-0.10.0.0
-- proto-lens-0.5.1.0
+- warp-3.3.15
+- warp-tls-3.2.12
+- tls-1.5.4
+- tls-session-manager-0.0.4@sha256:3b2e7e40b5be043b35a19fe1ed8b7e016a9c827f55777a9f9cb5e08860390d5d,1031
+- network-byte-order-0.1.6@sha256:23d8b609ac43a69d04d5e8f411e5f86a0266c0e8b33b65f8c92ebda64273fe3a,1313
+- time-manager-0.0.0@sha256:d258b1d08f9b926823f5380e9201303b0ebeefe4f9e0047c0cbd7b6728135ee1,657

--- a/stack-14.yaml
+++ b/stack-14.yaml
@@ -1,5 +1,4 @@
 resolver: lts-14.27
-allow-newer: true
 packages:
 - http2-grpc-types
 - http2-grpc-proto-lens
@@ -8,4 +7,10 @@ packages:
 - http2-client-grpc
 extra-deps:
 - proto3-wire-1.0.0
-- http2-client-0.10.0.0
+- http2-3.0.3@sha256:309c7198fbccf136e949a2b630d7fec2557478c4af4a2c8c5523b71ec00c88b9,15906
+- git: https://github.com/lucasdicioccio/http2-client
+  commit: 046b1f23ea547b75f1a3dc3d878603968bff4fb4
+- warp-3.3.15
+- warp-tls-3.2.12
+- tls-1.5.4
+- network-byte-order-0.1.6@sha256:23d8b609ac43a69d04d5e8f411e5f86a0266c0e8b33b65f8c92ebda64273fe3a,1313

--- a/stack-15.yaml
+++ b/stack-15.yaml
@@ -1,5 +1,4 @@
-resolver: lts-15.4
-allow-newer: true
+resolver: lts-15.16
 packages:
 - http2-grpc-types
 - http2-grpc-proto-lens
@@ -7,5 +6,10 @@ packages:
 - warp-grpc
 - http2-client-grpc
 extra-deps:
-- proto3-wire-1.0.0
-- http2-client-0.10.0.0
+- http2-3.0.3
+- git: https://github.com/lucasdicioccio/http2-client
+  commit: 046b1f23ea547b75f1a3dc3d878603968bff4fb4
+- warp-3.3.15
+- proto3-wire-1.3.0@sha256:45220b0c7ad6e62521bacc18a71dff5e8eb6b77cfdbead14176385e2a35e1c12,2811
+- parameterized-0.5.0.0@sha256:880717fbb958de1bac015f0a375ab6636f162a72483d987a11e305da6fac6c97,1969
+- word-compat-0.0.2@sha256:c881977321de67d6f1d0cafe805e66d771a6e0614cafaa2104391f44cf4afd21,1202

--- a/stack-16.yaml
+++ b/stack-16.yaml
@@ -1,5 +1,4 @@
-resolver: lts-16.20
-allow-newer: true
+resolver: lts-16.31
 packages:
 - http2-grpc-types
 - http2-grpc-proto-lens
@@ -8,5 +7,7 @@ packages:
 - http2-client-grpc
 - bench-tool
 extra-deps:
-- proto3-wire-1.0.0
-- http2-client-0.10.0.0
+- http2-3.0.3
+- git: https://github.com/lucasdicioccio/http2-client
+  commit: 046b1f23ea547b75f1a3dc3d878603968bff4fb4
+- warp-3.3.15

--- a/stack-17.yaml
+++ b/stack-17.yaml
@@ -1,5 +1,4 @@
-resolver: lts-17.2
-allow-newer: true
+resolver: lts-17.15
 packages:
   - http2-grpc-types
   - http2-grpc-proto-lens
@@ -8,5 +7,7 @@ packages:
   - http2-client-grpc
   - bench-tool
 extra-deps:
-  - proto3-wire-1.0.0
-  - http2-client-0.10.0.0
+  - http2-3.0.3
+  - git: https://github.com/lucasdicioccio/http2-client
+    commit: 046b1f23ea547b75f1a3dc3d878603968bff4fb4
+  - warp-3.3.15

--- a/stack-18.yaml
+++ b/stack-18.yaml
@@ -1,5 +1,4 @@
-resolver: lts-18.3
-allow-newer: true
+resolver: lts-18.28
 packages:
   - http2-grpc-types
   - http2-grpc-proto-lens
@@ -8,9 +7,7 @@ packages:
   - http2-client-grpc
   - bench-tool
 extra-deps:
-  - http2-2.0.6
-  - http2-client-0.10.0.0
-  - proto-lens-0.7.0.0
-  - proto-lens-runtime-0.7.0.0
-  - proto3-wire-1.0.0
-  - warp-3.3.14
+  - git: https://github.com/lucasdicioccio/http2-client
+    commit: 046b1f23ea547b75f1a3dc3d878603968bff4fb4
+  - proto-lens-0.7.1.1@sha256:8419e86fd7f521206a991c3ccb1777332a07a8250b380b06694f9f301b1ff38d,2972
+  - proto-lens-runtime-0.7.0.2@sha256:25d11fd08b56025c89e6be5da46f40a82bd845218b235b9e0114253b45caa074,3051

--- a/stack-19.yaml
+++ b/stack-19.yaml
@@ -1,10 +1,12 @@
-resolver: nightly-2022-06-19
+resolver: lts-19.13
+system-ghc: true
 packages:
-  - http2-client-grpc
+  - http2-grpc-types
   - http2-grpc-proto-lens
   - http2-grpc-proto3-wire
-  - http2-grpc-types
   - warp-grpc
+  - http2-client-grpc
+  - bench-tool
 extra-deps:
   - git: https://github.com/lucasdicioccio/http2-client
     commit: 046b1f23ea547b75f1a3dc3d878603968bff4fb4

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-18.yaml
+stack-19.yaml

--- a/test-builds.sh
+++ b/test-builds.sh
@@ -7,3 +7,4 @@ stack build --stack-yaml=stack-15.yaml
 stack build --stack-yaml=stack-16.yaml
 stack build --stack-yaml=stack-17.yaml
 stack build --stack-yaml=stack-18.yaml
+stack build --stack-yaml=stack-19.yaml

--- a/warp-grpc/package.yaml
+++ b/warp-grpc/package.yaml
@@ -19,14 +19,14 @@ dependencies:
 - base >= 4.10 && < 5
 - async >= 2.2.1 && < 3
 - binary >= 0.8.5 && < 0.9
-- bytestring >= 0.10.8 && < 0.11
+- bytestring >= 0.10.8 && < 0.12
 - case-insensitive >= 1.2.0 && < 1.3
-- http2 >= 1.6 && < 3
+- http2 >= 3.0 && < 3.1
 - http2-grpc-types >= 0.5 && < 0.6
 - http-types >= 0.12 && < 0.13
 - unliftio-core >= 0.1 && < 0.3
 - wai >= 3.2 && < 3.4
-- warp >= 3.2.23 && < 3.4
+- warp >= 3.3.15 && < 3.4
 - warp-tls >= 3.2 && < 3.4
 
 library:


### PR DESCRIPTION
Attempts to resolve #59

The following changes where made to get this to build on GHC 9:
 
* Require `http2 >= 3.0` for GHC 9 support (http2-client-grpc, warp-grpc)
* Require `warp >= 3.3.15` for GHC 9 support (warp-grpc)
* Resolve module name conflicts between `http2` and `http2-client` with `PackageImports` extension (http2-client-grpc)
* Remove unused `http2` dependency (bench-tool)
* Relax upper bounds for `bytestring==0.12.*` (http2-grpc-proto-lens, http2-grpc-proto3-wire, http2-grpc-types, warp-grpc)
* Relax upper bounds for `proto3-wire <= 1.4` (http2-grpc-proto3-wire)
* Add stack-19.yaml as default and update existing yamls

Note that `http2-client >= 0.10.0.1` is required as git dependency in `extra-deps` of the `stack.yaml` files to get this to build. This can probably be moved to version bounds if the new version of http2-client is ever published.