### PR TITLE
Cabalify warp-grpc

### DIFF
--- a/warp-grpc/.gitignore
+++ b/warp-grpc/.gitignore
@@ -1,5 +1,3 @@
 .stack-work/
-http2-server-grpc.cabal
-warp-grpc.cabal
 *~
 stack.yaml.lock

--- a/warp-grpc/warp-grpc.cabal
+++ b/warp-grpc/warp-grpc.cabal
@@ -1,0 +1,54 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.7.
+--
+-- see: https://github.com/sol/hpack
+
+name:           warp-grpc
+version:        0.4.0.1
+synopsis:       A minimal gRPC server on top of Warp.
+description:    Please see the README on Github at <https://github.com/haskell-grpc-native/http2-grpc-haskell/blob/master/warp-grpc/README.md>
+category:       Networking
+homepage:       https://github.com/haskell-grpc-native/http2-grpc-haskell#readme
+bug-reports:    https://github.com/haskell-grpc-native/http2-grpc-haskell/issues
+author:         Lucas DiCioccio, Alejandro Serrano
+maintainer:     lucas@dicioccio.fr
+copyright:      2017 - 2020 Lucas DiCioccio, Alejandro Serrano
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/haskell-grpc-native/http2-grpc-haskell
+
+library
+  exposed-modules:
+      Network.GRPC.Server
+      Network.GRPC.Server.Handlers
+      Network.GRPC.Server.Handlers.Trans
+      Network.GRPC.Server.Handlers.Unlift
+      Network.GRPC.Server.Helpers
+      Network.GRPC.Server.Wai
+  other-modules:
+      Paths_warp_grpc
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      async >=2.2.1 && <3
+    , base >=4.10 && <5
+    , binary >=0.8.5 && <0.9
+    , bytestring >=0.10.8 && <0.11
+    , case-insensitive >=1.2.0 && <1.3
+    , http-types ==0.12.*
+    , http2 >=1.6 && <3
+    , http2-grpc-types ==0.5.*
+    , unliftio-core >=0.1 && <0.3
+    , wai >=3.2 && <3.4
+    , warp >=3.2.23 && <3.4
+    , warp-tls >=3.2 && <3.4
+  default-language: Haskell2010


### PR DESCRIPTION
DONE

- [ ] Removed Cabal files from `.ignore`
  - QUESTION: Was it intentional to have it there?
- [ ] Used `hpack` to create `warp-grpc.cabal`