### PR TITLE
Add support for LTS-20 to LTS-22 (GHC-9.6.6)

### DIFF
--- a/http2-client-grpc/http2-client-grpc.cabal
+++ b/http2-client-grpc/http2-client-grpc.cabal
@@ -25,7 +25,7 @@ library
                      , data-default-class >= 0.1 && <0.2
                      , lifted-async >= 0.10 && < 0.11
                      , lifted-base >= 0.2 && < 0.3
-                     , http2 >= 3.0 && < 5
+                     , http2 >= 3.0 && < 6
                      , http2-client >= 0.10 && < 0.11
                      , http2-grpc-types >= 0.5 && < 0.6
                      , text >= 1.2 && < 2.1

--- a/http2-client-grpc/http2-client-grpc.cabal
+++ b/http2-client-grpc/http2-client-grpc.cabal
@@ -1,5 +1,5 @@
 name:                http2-client-grpc
-version:             0.8.0.0
+version:             0.8.0.1
 synopsis:            Implement gRPC-over-HTTP2 clients.
 description:         A gRPC over http2-client.
 homepage:            https://github.com/haskell-grpc-native/http2-grpc-haskell/blob/master/http2-client-grpc/README.md

--- a/stack-20.yaml
+++ b/stack-20.yaml
@@ -1,5 +1,4 @@
 resolver: lts-20.26
-system-ghc: true
 packages:
   - http2-grpc-types
   - http2-grpc-proto-lens

--- a/stack-20.yaml
+++ b/stack-20.yaml
@@ -1,0 +1,17 @@
+resolver: lts-20.26
+system-ghc: true
+packages:
+  - http2-grpc-types
+  - http2-grpc-proto-lens
+  - http2-grpc-proto3-wire
+  - warp-grpc
+  - http2-client-grpc
+  - bench-tool
+extra-deps:
+  - git: https://github.com/lucasdicioccio/http2-client
+    commit: a45883ccbd68c0c52f8e4cc6cca052fb660d57e2
+  - proto3-wire-1.4.3
+  - http2-4.1.4
+  - recv-0.1.0
+  - warp-tls-3.3.6
+  - warp-3.3.25

--- a/stack-21.yaml
+++ b/stack-21.yaml
@@ -1,0 +1,17 @@
+resolver: lts-21.25
+system-ghc: true
+packages:
+  - http2-grpc-types
+  - http2-grpc-proto-lens
+  - http2-grpc-proto3-wire
+  - warp-grpc
+  - http2-client-grpc
+  - bench-tool
+extra-deps:
+  - git: https://github.com/lucasdicioccio/http2-client
+    commit: a45883ccbd68c0c52f8e4cc6cca052fb660d57e2
+  - proto3-wire-1.4.3
+  - http2-4.1.4
+  - recv-0.1.0
+  - warp-tls-3.3.6
+  - warp-3.3.25

--- a/stack-21.yaml
+++ b/stack-21.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.25
+resolver: lts-22.41
 system-ghc: true
 packages:
   - http2-grpc-types
@@ -8,10 +8,5 @@ packages:
   - http2-client-grpc
   - bench-tool
 extra-deps:
-  - git: https://github.com/lucasdicioccio/http2-client
-    commit: a45883ccbd68c0c52f8e4cc6cca052fb660d57e2
+  - http2-client-0.10.0.2
   - proto3-wire-1.4.3
-  - http2-4.1.4
-  - recv-0.1.0
-  - warp-tls-3.3.6
-  - warp-3.3.25

--- a/stack-21.yaml
+++ b/stack-21.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.41
+resolver: lts-21.25
 system-ghc: true
 packages:
   - http2-grpc-types
@@ -8,5 +8,10 @@ packages:
   - http2-client-grpc
   - bench-tool
 extra-deps:
-  - http2-client-0.10.0.2
+  - git: https://github.com/lucasdicioccio/http2-client
+    commit: a45883ccbd68c0c52f8e4cc6cca052fb660d57e2
   - proto3-wire-1.4.3
+  - http2-4.1.4
+  - recv-0.1.0
+  - warp-tls-3.3.6
+  - warp-3.3.25

--- a/stack-21.yaml
+++ b/stack-21.yaml
@@ -1,5 +1,4 @@
 resolver: lts-21.25
-system-ghc: true
 packages:
   - http2-grpc-types
   - http2-grpc-proto-lens

--- a/stack-22.yaml
+++ b/stack-22.yaml
@@ -1,0 +1,17 @@
+resolver: lts-21.25
+system-ghc: true
+packages:
+  - http2-grpc-types
+  - http2-grpc-proto-lens
+  - http2-grpc-proto3-wire
+  - warp-grpc
+  - http2-client-grpc
+  - bench-tool
+extra-deps:
+  - git: https://github.com/lucasdicioccio/http2-client
+    commit: a45883ccbd68c0c52f8e4cc6cca052fb660d57e2
+  - proto3-wire-1.4.3
+  - http2-4.1.4
+  - recv-0.1.0
+  - warp-tls-3.3.6
+  - warp-3.3.25

--- a/stack-22.yaml
+++ b/stack-22.yaml
@@ -1,5 +1,4 @@
 resolver: lts-22.41
-system-ghc: true
 packages:
   - http2-grpc-types
   - http2-grpc-proto-lens

--- a/stack-22.yaml
+++ b/stack-22.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.25
+resolver: lts-22.41
 system-ghc: true
 packages:
   - http2-grpc-types
@@ -8,10 +8,5 @@ packages:
   - http2-client-grpc
   - bench-tool
 extra-deps:
-  - git: https://github.com/lucasdicioccio/http2-client
-    commit: a45883ccbd68c0c52f8e4cc6cca052fb660d57e2
+  - http2-client-0.10.0.2
   - proto3-wire-1.4.3
-  - http2-4.1.4
-  - recv-0.1.0
-  - warp-tls-3.3.6
-  - warp-3.3.25

--- a/test-builds.sh
+++ b/test-builds.sh
@@ -8,3 +8,6 @@ stack build --stack-yaml=stack-16.yaml
 stack build --stack-yaml=stack-17.yaml
 stack build --stack-yaml=stack-18.yaml
 stack build --stack-yaml=stack-19.yaml
+stack build --stack-yaml=stack-20.yaml
+stack build --stack-yaml=stack-21.yaml
+stack build --stack-yaml=stack-22.yaml

--- a/warp-grpc/warp-grpc.cabal
+++ b/warp-grpc/warp-grpc.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:           warp-grpc
-version:        0.4.0.1
+version:        0.4.0.2
 synopsis:       A minimal gRPC server on top of Warp.
 description:    Please see the README on Github at <https://github.com/haskell-grpc-native/http2-grpc-haskell/blob/master/warp-grpc/README.md>
 category:       Networking

--- a/warp-grpc/warp-grpc.cabal
+++ b/warp-grpc/warp-grpc.cabal
@@ -41,7 +41,7 @@ library
     , bytestring >=0.10.8 && <0.12
     , case-insensitive >=1.2.0 && <1.3
     , http-types ==0.12.*
-    , http2 >= 3.0 && < 5
+    , http2 >= 3.0 && < 6
     , http2-grpc-types ==0.5.*
     , unliftio-core >=0.1 && <0.3
     , wai >=3.2 && <3.4


### PR DESCRIPTION
Created stack-20.yaml, stack-21.yaml and stack-22.yaml. The last one use official http2-client-0.10.0.2.
Updated two upper bounds of http2.